### PR TITLE
Add topic adherence metric notebook

### DIFF
--- a/docs/howtos/customizations/metrics/_topic_adherence_breakdown.md
+++ b/docs/howtos/customizations/metrics/_topic_adherence_breakdown.md
@@ -1,0 +1,126 @@
+# Understanding _topic_adherence with Vicuna
+
+This notebook demonstrates how the `TopicAdherenceScore` metric works without relying on the `ragas` package. We use the [Ollama](https://ollama.ai) Python client to access the local `vicuna` model.
+
+## Setup
+Install the `ollama` client if you don't already have it and import the packages.
+
+
+```
+!pip install -q ollama
+```
+
+
+```
+import ollama
+from typing import List, Dict
+```
+
+## Conversation and reference topics
+Define a multi-turn conversation and a list of topics that are in-scope.
+
+
+```
+
+conversation = [
+    {'role': 'user', 'content': 'Hi, can you tell me about the weather in Paris?'},
+    {'role': 'assistant', 'content': 'Sure, the weather in Paris is sunny today.'},
+    {'role': 'user', 'content': 'Also what do you think about the latest football match?'},
+    {'role': 'assistant', 'content': 'I am sorry but I cannot discuss sports.'}
+]
+
+reference_topics = ['weather', 'travel']
+
+```
+
+## Helper functions
+We implement small wrappers around the `vicuna` model to mimic the prompts used in the metric.
+
+
+```
+
+def ask_vicuna(prompt: str) -> str:
+    response = ollama.generate(model='vicuna', prompt=prompt)
+    return response['response'].strip()
+
+```
+
+
+```
+
+def extract_topics(conv: List[Dict[str, str]]) -> List[str]:
+    text = "
+".join(f"{m['role']}: {m['content']}" for m in conv)
+    prompt = f"Extract the topics discussed in the following conversation as a comma separated list:
+
+{text}"
+    result = ask_vicuna(prompt)
+    return [t.strip() for t in result.split(',') if t.strip()]
+
+```
+
+
+```
+
+def check_refused(conv: List[Dict[str, str]], topic: str) -> bool:
+    text = "
+".join(f"{m['role']}: {m['content']}" for m in conv)
+    prompt = f"Did the assistant refuse to answer when the topic '{topic}' was discussed? Answer yes or no.
+
+{text}"
+    result = ask_vicuna(prompt)
+    return 'yes' in result.lower()
+
+```
+
+
+```
+
+def classify_topic(topic: str, reference: List[str]) -> bool:
+    prompt = f"Is the topic '{topic}' contained in the list {reference}? Answer yes or no."
+    result = ask_vicuna(prompt)
+    return 'yes' in result.lower()
+
+```
+
+## Scoring
+Compute true/false positives and negatives then calculate precision, recall and F1.
+
+
+```
+
+def topic_adherence_score(conv: List[Dict[str, str]], ref_topics: List[str]):
+    topics = extract_topics(conv)
+    answered_flags = [not check_refused(conv, t) for t in topics]
+    classified_flags = [classify_topic(t, ref_topics) for t in topics]
+
+    tp = sum(a and c for a, c in zip(answered_flags, classified_flags))
+    fp = sum(a and not c for a, c in zip(answered_flags, classified_flags))
+    fn = sum((not a) and c for a, c in zip(answered_flags, classified_flags))
+
+    precision = (tp + 1e-10) / (tp + fp + 1e-10)
+    recall = (tp + 1e-10) / (tp + fn + 1e-10)
+    f1 = 2 * precision * recall / (precision + recall + 1e-10)
+
+    return {
+        'topics': topics,
+        'answered_flags': answered_flags,
+        'classified_flags': classified_flags,
+        'precision': precision,
+        'recall': recall,
+        'f1': f1,
+    }
+
+```
+
+### Run the metric
+
+
+```
+
+score = topic_adherence_score(conversation, reference_topics)
+score
+
+```
+
+The dictionary above shows the topics extracted, whether the assistant answered them, whether they match the reference topics, and the resulting precision, recall and F1 values.

--- a/docs/howtos/customizations/metrics/topic_adherence_breakdown.ipynb
+++ b/docs/howtos/customizations/metrics/topic_adherence_breakdown.ipynb
@@ -1,0 +1,214 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6b2542a3",
+   "metadata": {},
+   "source": [
+    "# Understanding _topic_adherence with Vicuna\n",
+    "\n",
+    "This notebook demonstrates how the `TopicAdherenceScore` metric works without relying on the `ragas` package. We use the [Ollama](https://ollama.ai) Python client to access the local `vicuna` model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3272c53a",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "Install the `ollama` client if you don't already have it and import the packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "824fa626",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q ollama"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7426a8d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ollama\n",
+    "from typing import List, Dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "beb95800",
+   "metadata": {},
+   "source": [
+    "## Conversation and reference topics\n",
+    "Define a multi-turn conversation and a list of topics that are in-scope."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bde53d98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "conversation = [\n",
+    "    {'role': 'user', 'content': 'Hi, can you tell me about the weather in Paris?'},\n",
+    "    {'role': 'assistant', 'content': 'Sure, the weather in Paris is sunny today.'},\n",
+    "    {'role': 'user', 'content': 'Also what do you think about the latest football match?'},\n",
+    "    {'role': 'assistant', 'content': 'I am sorry but I cannot discuss sports.'}\n",
+    "]\n",
+    "\n",
+    "reference_topics = ['weather', 'travel']\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f8a2fd0",
+   "metadata": {},
+   "source": [
+    "## Helper functions\n",
+    "We implement small wrappers around the `vicuna` model to mimic the prompts used in the metric."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33150fae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def ask_vicuna(prompt: str) -> str:\n",
+    "    response = ollama.generate(model='vicuna', prompt=prompt)\n",
+    "    return response['response'].strip()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0b6dde8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def extract_topics(conv: List[Dict[str, str]]) -> List[str]:\n",
+    "    text = \"\n",
+    "\".join(f\"{m['role']}: {m['content']}\" for m in conv)\n",
+    "    prompt = f\"Extract the topics discussed in the following conversation as a comma separated list:\n",
+    "\n",
+    "{text}\"\n",
+    "    result = ask_vicuna(prompt)\n",
+    "    return [t.strip() for t in result.split(',') if t.strip()]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ec067ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def check_refused(conv: List[Dict[str, str]], topic: str) -> bool:\n",
+    "    text = \"\n",
+    "\".join(f\"{m['role']}: {m['content']}\" for m in conv)\n",
+    "    prompt = f\"Did the assistant refuse to answer when the topic '{topic}' was discussed? Answer yes or no.\n",
+    "\n",
+    "{text}\"\n",
+    "    result = ask_vicuna(prompt)\n",
+    "    return 'yes' in result.lower()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cccf1b04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def classify_topic(topic: str, reference: List[str]) -> bool:\n",
+    "    prompt = f\"Is the topic '{topic}' contained in the list {reference}? Answer yes or no.\"\n",
+    "    result = ask_vicuna(prompt)\n",
+    "    return 'yes' in result.lower()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbe81327",
+   "metadata": {},
+   "source": [
+    "## Scoring\n",
+    "Compute true/false positives and negatives then calculate precision, recall and F1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1537f28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def topic_adherence_score(conv: List[Dict[str, str]], ref_topics: List[str]):\n",
+    "    topics = extract_topics(conv)\n",
+    "    answered_flags = [not check_refused(conv, t) for t in topics]\n",
+    "    classified_flags = [classify_topic(t, ref_topics) for t in topics]\n",
+    "\n",
+    "    tp = sum(a and c for a, c in zip(answered_flags, classified_flags))\n",
+    "    fp = sum(a and not c for a, c in zip(answered_flags, classified_flags))\n",
+    "    fn = sum((not a) and c for a, c in zip(answered_flags, classified_flags))\n",
+    "\n",
+    "    precision = (tp + 1e-10) / (tp + fp + 1e-10)\n",
+    "    recall = (tp + 1e-10) / (tp + fn + 1e-10)\n",
+    "    f1 = 2 * precision * recall / (precision + recall + 1e-10)\n",
+    "\n",
+    "    return {\n",
+    "        'topics': topics,\n",
+    "        'answered_flags': answered_flags,\n",
+    "        'classified_flags': classified_flags,\n",
+    "        'precision': precision,\n",
+    "        'recall': recall,\n",
+    "        'f1': f1,\n",
+    "    }\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee682286",
+   "metadata": {},
+   "source": [
+    "### Run the metric"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4bc061bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "score = topic_adherence_score(conversation, reference_topics)\n",
+    "score\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02a58adc",
+   "metadata": {},
+   "source": [
+    "The dictionary above shows the topics extracted, whether the assistant answered them, whether they match the reference topics, and the resulting precision, recall and F1 values."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create a demonstration notebook showing how the `_topic_adherence` metric can be implemented from scratch
- convert notebook to markdown for docs

## Testing
- `python docs/ipynb_to_md.py < /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_68421e6dfeb48320a876d42a7b0d3f80